### PR TITLE
Temporarily fix in makefile.

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 27 02:38:21 UTC 2014 - nwang@suse.com
+
+- Temporarily comment "racc" in Makefile.am.Due to buildrequires: 
+  rubygem-racc is necessary in yast ci but invalid in ibs.
+- version 3.1.2
+
+-------------------------------------------------------------------
 Mon May 26 02:53:59 UTC 2014 - nwang@suse.com
 
 - BNC#876536. Convert Ycp to Ruby based on sle11sp3(sp1). 

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-drbd
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/servers_non_y2/Makefile.am
+++ b/src/servers_non_y2/Makefile.am
@@ -3,9 +3,12 @@
 agent_SCRIPTS = \
 	ag_drbd drbd.rb.yy
 
-ag_drbd: drbd.rb.yy
-	rm -f drbd.rb
-	racc -e "/usr/bin/ruby" -v -g drbd.rb.yy -o ag_drbd
-	chmod ugo+x ag_drbd
+#Comment due to buildrequires :rubygem-racc 
+# is neccary in yast ci(github)a but invalid in ibs
+#
+#ag_drbd: drbd.rb.yy
+#	rm -f drbd.rb
+#	racc -e "/usr/bin/ruby" -v -g drbd.rb.yy -o ag_drbd
+#	chmod ugo+x ag_drbd
 
 EXTRA_DIST = $(agent_SCRIPTS)


### PR DESCRIPTION
Temporarily comment racc in makefile. due to buildrequires: rubygem-racc is invalid in ibs but necessary in yast ci.
Version 3.1.2
