### PR TITLE
bsc#1082507, add missing colon for ruby instance. Version 4.0.2

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 23 09:52:06 UTC 2018 - nwang@suse.com
+
+- bsc#1082507, add missing colon for ruby instance
+- Version 4.0.2
+
+-------------------------------------------------------------------
 Fri Jan 26 06:58:42 UTC 2018 - nwang@suse.com
 
 - SuSEFirewall2 replace by firewalld(fate#323460)

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-drbd
 #
-# Copyright (c) 2016 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-drbd
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 %define _fwdefdir %{_libexecdir}/firewalld/services

--- a/src/modules/Drbd.rb
+++ b/src/modules/Drbd.rb
@@ -802,7 +802,7 @@ module Yast
   private
 
     def firewalld
-      Y2Firewall:Firewalld.instance
+      Y2Firewall::Firewalld.instance
     end
 
   end


### PR DESCRIPTION
Fix the missing colon for the ruby instance