### PR TITLE
jsc#SLE-5498, lvmetad is removed in lvm2 since 2.03.05

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 31 10:26:12 UTC 2019 - nick wang <nwang@suse.com>
+
+- jsc#SLE-5498, lvmetad is removed in lvm2 since 2.03.05
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri May 31 12:29:27 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-drbd
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-drbd
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later

--- a/src/include/drbd/helps.rb
+++ b/src/include/drbd/helps.rb
@@ -126,8 +126,6 @@ module Yast
               "\n" +
               "\t\t<p><b>LVM cache</b>: Enable/turn on writing the LVM cache is default. Should disable the LVM cache when combined drbd with LVM.</p>\n" +
               "\n" +
-              "\t\t<p><b>LVMetad</b>: When lvmetad is enabled, the volume group metadata and PV state flags are obtained from the lvmetad instance and no scanning is done by the individual commands. Because lvmetad's cache cannot be synchronized between nodes, users are advised to disable lvmetad in cluster environments.</p>\n" +
-              "\n" +
               "\t\t"
           ),
         "global_conf"   => _(

--- a/src/include/drbd/lvm_conf.rb
+++ b/src/include/drbd/lvm_conf.rb
@@ -14,18 +14,11 @@ module Yast
 
       @filter = ""
       @cache = true
-      @lvmetad = false
 
     end
 
     def lvm_conf_Read
       @filter = Ops.get_string( Drbd.lvm_config, "filter", "" )
-      lvmetad_str = Ops.get_string( Drbd.lvm_config, "use_lvmetad", "0" )
-      if lvmetad_str == "0"
-        @lvmetad = false
-      else
-        @lvmetad = true
-      end
 
       cache_str = Ops.get_string( Drbd.lvm_config, "write_cache_state", "0" )
       if cache_str == "0"
@@ -81,37 +74,10 @@ module Yast
         )
       )
 
-      _Tlvmetad = Frame(
-        _("Use lvmetad for LVM"),
-        Left(
-          HSquash(
-            VBox(
-              VBox(
-                Left(
-                  CheckBox(
-                    Id(:LVMetad),
-                    Opt(:notify),
-                    _("Use LVM metad"),
-                    @lvmetad
-                  )
-                ),
-                Left(Label(
-                  _(
-                    "Warning!  Should not use lvmetad for cluster."
-                  )
-                )),
-              ),
-            )
-          )
-        )
-      )
-
       VBox(
         _Tfilter,
         VSpacing(1),
         _Tcache,
-        VSpacing(1),
-        _Tlvmetad,
         VStretch()
       )
     end
@@ -126,15 +92,7 @@ module Yast
         cache_str = "0"
       end
 
-      @lvmetad = UI.QueryWidget(Id(:LVMetad), :Value)
-      if @lvmetad
-        lvmetad_str = "1"
-      else
-        lvmetad_str = "0"
-      end
-
       Ops.set(Drbd.lvm_config, "write_cache_state", cache_str)
-      Ops.set(Drbd.lvm_config, "use_lvmetad", lvmetad_str)
 
       Ops.set(Drbd.lvm_config, "filter", @filter)
 

--- a/src/modules/Drbd.rb
+++ b/src/modules/Drbd.rb
@@ -299,16 +299,6 @@ module Yast
         end
 
         #read LVM configs via /etc/lvm/lvm.conf
-        #Disable use_lvmetad when using yast drbd to avoid lvmetad
-        #in cluster environment, but it may also effect regular usage
-        #Manually enable use_lvmetad in this case
-        val = Convert.to_string(
-            SCR.Read(Builtins.topath(Builtins.sformat(".drbd_lvm.value.global.%1",
-                     "use_lvmetad")))
-          )
-        Ops.set(@lvm_config, "use_lvmetad", val)
-        y2debug("drbd_lvm.global.%1 is %2", "use_lvmetad", val)
-
         #All of them under "devices" section
         ["filter", "write_cache_state", "cache_dir"].each do |key|
           val = Convert.to_string(
@@ -708,13 +698,6 @@ module Yast
             Ops.get(@lvm_config, key)
           )
         end
-      end
-
-      if Ops.get(@lvm_config, "use_lvmetad") != nil
-        SCR.Write(
-          Builtins.topath(Builtins.sformat(".drbd_lvm.value.global.%1", "use_lvmetad")),
-          Ops.get(@lvm_config, "use_lvmetad")
-        )
       end
 
       if Ops.get(@lvm_config, "write_cache_state") == "0"


### PR DESCRIPTION
Remove the lvmetad configure part.