### PR TITLE
Fix packaging: do not rely on libexecdir pointing to /usr/lib (bsc#1174075)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-drbd-image yast-travis-ruby
+  - docker run -it --privileged -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-drbd-image yast-travis-ruby

--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 23 09:36:14 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- RPM Packaging: do not rely on libexecdir being expanded to
+  /usr/lib, which is not always the case (bsc#1174075).
+- 4.3.0
+
+-------------------------------------------------------------------
 Thu Oct 31 10:26:12 UTC 2019 - nick wang <nwang@suse.com>
 
 - jsc#SLE-5498, lvmetad is removed in lvm2 since 2.03.05

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-drbd
-Version:        4.2.2
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -73,7 +73,7 @@ install -m 644 %{S:1} %{buildroot}%{_fwdefdir}/drbd.xml
 %{yast_agentdir}
 %doc %{yast_docdir}
 %license COPYING
-%dir %{_libexecdir}/firewalld
+%dir %{_prefix}/lib/firewalld
 %dir %{_fwdefdir}
 %{_fwdefdir}/drbd.xml
 %{yast_icondir}


### PR DESCRIPTION
## Problem

This package includes a `/usr/lib/firewalld` directory. In the spec file that was specified as `%{_libexecdir}/firewalld` because (open)SUSE used to expand `%{_libexecdir}` as `/usr/lib` (there was not provision for `%_libexecdir` in older versions of the [FHS](https://www.pathname.com/fhs/)).

But FHS 3.0 defines that `%_libexecdir` must be expanded as `/usr/libexec` and openSUSE Tumbleweed is being adapted to honor that. Thus, the previous way of specifying `/usr/lib/firewalld` on this package would not longer be valid.

## Solution

Use `%{_prefix}/lib/firewalld` that should be correctly expanded as `/usr/lib/firewalld" in all versions of (open)SUSE.