### PR TITLE
Open ports for linstor packages.

### DIFF
--- a/package/drbd.firewalld.xml
+++ b/package/drbd.firewalld.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST DRBD</short>
-  <description>This allows you to open various ports related to SUSE YaST DRBD including Linstor support. 3366/3367 for lnstor satellite. 3370/3376/3377 for linstor controller. 3371 for linstor-controller when using HTTPS REST-API. Port 7788 is the default port of DRBD connection. 7788 and higher are recommend to resource connections.</description>
+  <description>This allows you to open various ports related to SUSE
+		  YaST DRBD including Linstor support. Ports 3366/3367 are for
+		  lnstor satellite, ports 3370/3376/3377 are for linstor controller,
+		  and port 3371 is for linstor-controller when using HTTPS REST-API.
+		  Port 7788 is the default port for DRBD connection. Ports 7788 and
+		  higher are recommend to resource connections.
+  </description>
   <port protocol="tcp" port="7788"/>
   <port protocol="tcp" port="3366"/>
   <port protocol="tcp" port="3367"/>

--- a/package/drbd.firewalld.xml
+++ b/package/drbd.firewalld.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST DRBD</short>
-  <description>This allows you to open various ports related to SUSE YaST DRBD including Linstor support. Port 7788 and higher is recommend.</description>
+  <description>This allows you to open various ports related to SUSE YaST DRBD including Linstor support. 3366/3367 for lnstor satellite. 3370/3376/3377 for linstor controller. 3371 for linstor-controller when using HTTPS REST-API. Port 7788 is the default port of DRBD connection. 7788 and higher are recommend to resource connections.</description>
   <port protocol="tcp" port="7788"/>
   <port protocol="tcp" port="3366"/>
   <port protocol="tcp" port="3367"/>

--- a/package/drbd.firewalld.xml
+++ b/package/drbd.firewalld.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST DRBD</short>
-  <description>This allows you to open various ports related to SUSE YaST DRBD. Port 7788 and higher is recommend.</description>
+  <description>This allows you to open various ports related to SUSE YaST DRBD including Linstor support. Port 7788 and higher is recommend.</description>
   <port protocol="tcp" port="7788"/>
+  <port protocol="tcp" port="3366"/>
+  <port protocol="tcp" port="3367"/>
+  <port protocol="tcp" port="3370"/>
+  <port protocol="tcp" port="3371"/>
+  <port protocol="tcp" port="3376"/>
+  <port protocol="tcp" port="3377"/>
 </service>

--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 11 03:00:24 UTC 2020 - nick wang <nwang@suse.com>
+
+- Open ports for DRBD linstor packages
+- 4.3.2
+
+-------------------------------------------------------------------
 Mon Aug 10 17:56:45 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(drdb) into the spec file

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -32,6 +32,7 @@ BuildRequires:  update-desktop-files
 # SuSEFirewall2 replaced by Firewalld(fate#323460)
 BuildRequires:  yast2 >= 4.0.39
 BuildRequires:  yast2-devtools >= 4.2.2
+Requires:       yast2 >= 4.0.39
 Requires:       drbd >= 9.0
 Requires:       yast2-ruby-bindings >= 1.0.0
 Supplements:    autoyast(drbd)

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-drbd
 #
-# Copyright (c) 2019 SUSE LLC.
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,34 +15,26 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%define _fwdefdir %{_libexecdir}/firewalld/services
 
+%define _fwdefdir %{_libexecdir}/firewalld/services
 Name:           yast2-drbd
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later
 Group:          System/YaST
-Url:            https://github.com/yast/yast-drbd
-
+URL:            https://github.com/yast/yast-drbd
 Source0:        %{name}-%{version}.tar.bz2
 Source1:        drbd.firewalld.xml
-
+BuildRequires:  firewall-macros
 BuildRequires:  ruby
 BuildRequires:  update-desktop-files
 # SuSEFirewall2 replaced by Firewalld(fate#323460)
 BuildRequires:  yast2 >= 4.0.39
 BuildRequires:  yast2-devtools >= 4.2.2
-BuildRequires:  firewall-macros
-
-# SuSEFirewall2 replaced by Firewalld(fate#323460)
-Requires:       yast2 >= 4.0.39
 Requires:       drbd >= 9.0
 Requires:       yast2-ruby-bindings >= 1.0.0
-
 Supplements:    autoyast(drbd)
-
-
 BuildArch:      noarch
 
 %description
@@ -61,7 +53,7 @@ used on high availability (HA) clusters.
 %yast_metainfo
 
 mkdir -p %{buildroot}%{_fwdefdir}
-install -m 644 %{S:1} %{buildroot}%{_fwdefdir}/drbd.xml
+install -m 644 %{SOURCE1} %{buildroot}%{_fwdefdir}/drbd.xml
 
 %post
 %firewalld_reload


### PR DESCRIPTION
DRBD linstor is submit into openSUSE:Factory, open necessary ports for firewalld.

3366/3367 for linstor-satellite
3370/3376/3377 for linstor-controller
3371 for linstor-controller when using HTTPS REST-API

version 4.3.2 with clean spec.