### PR TITLE
Correct firewall directory for %_libexecdir changes (bsc#1174075)

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 19 09:51:43 UTC 2020 - Callum Farmer <callumjfarmer13@gmail.com>
+
+- Correct firewall directory for %_libexecdir changes (bsc#1174075)
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 11 03:00:24 UTC 2020 - nick wang <nwang@suse.com>
 
 - Open ports for DRBD linstor packages (bsc#1175434)

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -16,9 +16,9 @@
 #
 
 
-%define _fwdefdir %{_libexecdir}/firewalld/services
+%define _fwdefdir %{_prefix}/lib/firewalld/services
 Name:           yast2-drbd
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
* Fixes for %_libexecdir changing to /usr/libexec (bsc#1174075)