### PR TITLE
[SLE-15-SP4] Validate DRBD Device name

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr  3 09:50:00 UTC 2023 - Xin Liang <xliang@suse.com>
+
+- Validate DRBD Device name (bsc#1207952)
+- 4.4.3
+
+-------------------------------------------------------------------
 Fri May 21 10:12:51 UTC 2021 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Do not make package noarch: we require a dependency (drbd) that

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -18,7 +18,7 @@
 
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 Name:           yast2-drbd
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later

--- a/src/include/drbd/resource_conf.rb
+++ b/src/include/drbd/resource_conf.rb
@@ -609,6 +609,16 @@ module Yast
       deep_copy(res_config)
     end
 
+    def ValidDeviceName
+      dev_name = UI.QueryWidget(Id(:n_devc), :Value).to_s
+      if ! (dev_name =~ /(\/dev\/|)(drbd0|drbd[1-9][0-9]*)$/)
+        Popup.Warning(_("Valid \"Device\" value should be:\n\
+- /dev/drbd0\n- /dev/drbd[1-9][0-9]*\n- drbd0\n- drbd[1-9][0-9]*"))
+        return false
+      end
+      true
+    end
+
     def ValidIPaddress
       addressField = Convert.to_string(UI.QueryWidget(Id(:n_addr), :Value))
 
@@ -739,6 +749,12 @@ module Yast
           end
 
           if ! ValidIPaddress()
+              invalid = true
+              ret = nil
+              next
+          end
+
+	  if ! ValidDeviceName()
               invalid = true
               ret = nil
               next


### PR DESCRIPTION
## Problem

The `Device` name in a DRBD resource configuration was missing validation.

The valid `Device` name should be:
- /dev/drbd0
- /dev/drbd[1-9][0-9]*
- drbd0
- drbd[1-9][0-9]*

## Solution
Add such validate method, give a hint when the value is invalid

