### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-drbd.changes
+++ b/package/yast2-drbd.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.2
 
 -------------------------------------------------------------------
 Mon Apr  4 19:50:30 UTC 2023 - Xin Liang <xliang@suse.com>

--- a/package/yast2-drbd.spec
+++ b/package/yast2-drbd.spec
@@ -18,7 +18,7 @@
 
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 Name:           yast2-drbd
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - DRBD Configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

SP6 branch is based on SP5 so evaluate changes in master and if version differs bump it to avoid version collision.


## Solution

As all patches are already in SP5 branch, just bump version to avoid version collision.